### PR TITLE
Add relative URL to font declaration.

### DIFF
--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:900);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:900);
 
 body {
   font-family: Arial;


### PR DESCRIPTION
Hi,

This fixes the mixed content warning when viewing page through https.

Thanks for the page!

Cheers,
